### PR TITLE
Make `colorMin` an optional argument

### DIFF
--- a/src/Programs.ts
+++ b/src/Programs.ts
@@ -389,7 +389,7 @@ void main() {
 	scale?: number,
 	opacity?: number,
 	colorMax?: number[],
-	colorMin: number[],
+	colorMin?: number[],
 	precision?: GLSLPrecision,
 }) {
 	const { type } = params;


### PR DESCRIPTION
Hi, thanks for writing this library! I saw it on Twitter and was super excited. You inspired me to go on a textbook-reading day with my friend about the Navier-Stokes equations a couple weeks ago.

Anyway I was trying to use the library and caught a small bug.

---

When running the example program in the README in TypeScript, I got type-checking errors because it said `colorMin` was required in `renderAmplitudeProgram`.

This change corrects the type definition to make `colorMin` optional.