### PR TITLE
functions for copying data to buffers directly on the GPU

### DIFF
--- a/docs/classes/GPULayer.md
+++ b/docs/classes/GPULayer.md
@@ -27,6 +27,7 @@
 - [clear](GPULayer.md#clear)
 - [getValues](GPULayer.md#getvalues)
 - [getValuesAsync](GPULayer.md#getvaluesasync)
+- [copyToWebGLBuffer](GPULayer.md#copytowebglbuffer)
 - [getImage](GPULayer.md#getimage)
 - [savePNG](GPULayer.md#savepng)
 - [attachToThreeTexture](GPULayer.md#attachtothreetexture)
@@ -277,6 +278,29 @@ This only works for WebGL2 contexts, will fall back to getValues() if WebGL1 con
 `Promise`<[`GPULayerArray`](../README.md#gpulayerarray)\>
 
 - A TypedArray containing current state of GPULayer.
+
+___
+
+### copyToWebGLBuffer
+
+▸ **copyToWebGLBuffer**(`dstBuffer`, `dstOffset?`, `srcX?`, `srcY?`, `srcWidth?`, `srcHeight?`): `void`
+
+Copies the contents of the layer to a WebGLBuffer.
+
+#### Parameters
+
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `dstBuffer` | `WebGLBuffer` | `undefined` | The WebGLBuffer to copy the contents of the layer to. |
+| `dstOffset` | `number` | `0` | The offset in bytes to start copying to. |
+| `srcX?` | `number` | `0` | The x coordinate of the source rectangle. |
+| `srcY?` | `number` | `0` | The y coordinate of the source rectangle. |
+| `srcWidth?` | `number` | `undefined` | The width of the source rectangle. |
+| `srcHeight?` | `number` | `undefined` | The height of the source rectangle. |
+
+#### Returns
+
+`void`
 
 ___
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,8 @@ const _testing = {
 	uniformInternalTypeForValue: utils.uniformInternalTypeForValue,
 	indexOfLayerInArray: utils.indexOfLayerInArray,
 	readPixelsAsync: utils.readPixelsAsync,
+	readPixelsToWebGLBuffer: utils.readPixelsToWebGLBuffer,
+	readPixelsToMultipleWebGLBuffers: utils.readPixelsToMultipleWebGLBuffers,
 	...extensions,
 	...regex,
 	...checks,

--- a/tests/mocha/GPULayer.js
+++ b/tests/mocha/GPULayer.js
@@ -730,5 +730,43 @@
 				// dispose() marks them for deletion, but they are garbage collected later.
 			});
 		});
+		describe('copy to GPU buffer', () => {
+			it('should copy values to a GPU buffer using `GPULayer.copyToWebGLBuffer`', async () => {
+				const composer = new GPUComposer({ canvas: document.createElement('canvas') });
+				const { gl } = composer;
+
+				const glBuffer = gl.createBuffer();
+
+				// simulate binding this buffer as a vertex attribute
+				gl.bindBuffer(gl.ARRAY_BUFFER, glBuffer);
+				gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([Math.random(), Math.random(), Math.random(), Math.random()]), gl.STATIC_DRAW);
+				
+				const layer1 = new GPULayer(composer, {
+					name: 'test',
+					type: FLOAT,
+					numComponents: 4,
+					dimensions: [1,1],
+					clearValue: 3,
+				});
+				// overwrite it with the pixels from the layer
+				layer1.clear();
+				
+				layer1.copyToWebGLBuffer(glBuffer);
+				
+				// read it back to an array
+				const array = new Float32Array(4);
+				gl.bindBuffer(gl.ARRAY_BUFFER, glBuffer);
+				gl.getBufferSubData(gl.ARRAY_BUFFER, 0, array);
+				
+				assert.equal(array[0], 3);
+				assert.equal(array[1], 3);
+				assert.equal(array[2], 3);
+				assert.equal(array[3], 3);
+
+				layer1.dispose();
+				composer.dispose();
+				gl.deleteBuffer(glBuffer);
+			});
+		})
 	});
 }


### PR DESCRIPTION
For #11 I got inspired to just go ahead and implement what I was imagining.

This PR adds some utility functions for copying framebuffer data to a single buffer (`readPixelsToWebGLBuffer`) and also to multiple buffers (`readPixelsToMultipleWebGLBuffers`).  Additionally, there's a simple `GPULayer.copyToWebGLBuffer` that uses `readPixelsToWebGLBuffer`.

This is WebGL2-only functionality.  I'd like to support mobile devices in my application but I was running out of framebuffer attachments, so my plan is to concatenate a bunch of data into a single `GPULayer` and use the `readPixelsToMultipleWebGLBuffers` to read them out to various buffers that I can use as vertex/instance attribute buffers.  This will also cut back on texture sampling.

Performance is still a :grey_question:  but hopefully it'll be better!