### PR TITLE
fix(package.json): point types field to the correct build file

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "src"
   ],
   "main": "dist/gpu-io.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/gpu-io.d.ts",
   "homepage": "https://apps.amandaghassaei.com/gpu-io/examples/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
First off, want to say thank you so much for the massive amount of work on this library 🙇🏻‍♂️

I'm just starting to dig into it for some personal 3D work, and noticed a small issue with the types. Description below:

### The Issue
When importing this project into a TypeScript file, a type declaration file cannot be found (screenshot below):

<img width="508" alt="Screenshot 2023-11-03 at 7 22 36 PM" src="https://github.com/amandaghassaei/gpu-io/assets/4651424/75534daa-6fb5-4fd2-87c0-448b45305979">

### Fix
Change the `package.json` "types" field to reference the correct output file, which is defined in the `rollup` config here: https://github.com/amandaghassaei/gpu-io/blob/main/rollup.config.mjs#L40

Changing this locally for `gpu-io` in my `node_modules` fixed the issue.